### PR TITLE
Remove .dylib symlink

### DIFF
--- a/generate.jai
+++ b/generate.jai
@@ -70,7 +70,7 @@ EOF;
 
             #if CPU == .ARM64 {
                 FOOTER :: #string EOF
-libsdl3 :: #library,system "libSDL3";
+libsdl3 :: #library "bin/arm64/libSDL3.0";
 EOF;
                 array_add(*opts.libpaths, "macos/bin/arm64");
             } else {

--- a/macos/bin/arm64/libSDL3.dylib
+++ b/macos/bin/arm64/libSDL3.dylib
@@ -1,1 +1,0 @@
-libSDL3.0.dylib

--- a/macos/macos.jai
+++ b/macos/macos.jai
@@ -36202,4 +36202,4 @@ SDL_GetRevision :: () -> *u8 #foreign libsdl3;
 
 #import "Basic"; // For push_context
 
-libsdl3 :: #library,system "libSDL3";
+libsdl3 :: #library "bin/arm64/libSDL3.0";


### PR DESCRIPTION
Removed `.dylib` symlink, made it use `libSDL3.0.dylib` instead.
It is also no longer treated as a system library.